### PR TITLE
fix node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Translates API $filter value to db query.",
   "main": "index.js",
   "engines": {
-    "node": "6.11.4"
+    "node": ">=6.11.4"
   },
   "scripts": {
     "test": "mocha tests/**/*.spec.js"


### PR DESCRIPTION
### WHAT WAS CHANGED

Fixed `filter2dbquery@0.1.0: The engine "node" is incompatible with this module. Expected version "6.11.4". Got "14.15.5"` issue